### PR TITLE
fix: update install command and import name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a fork of the [tailwindcss-animate](https://github.com/jamie-kyle/tailwi
 Install the plugin from npm:
 
 ```sh
-npm install -D tailwindcss-animate
+npm install -D @nobie-org/tailwindcss-animate
 ```
 
 Then add the plugin to your `tailwind.config.js` file:
@@ -37,7 +37,7 @@ module.exports = {
 		// ...
 	},
 	plugins: [
-		require("tailwindcss-animate"),
+		require("@nobie-org/tailwindcss-animate"),
 		// ...
 	],
 }


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to reflect the new package name for the plugin. The most important changes are:

* Updated the npm install command to use the new package name `@nobie-org/tailwindcss-animate` instead of `tailwindcss-animate`.
* Updated the `tailwind.config.js` example to require the new package name `@nobie-org/tailwindcss-animate` instead of `tailwindcss-animate`.